### PR TITLE
Add rotating 3D preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,18 @@
 # 3D-Fbx-Glb-Editor
 
-This repository contains a simple command line tool for copying FBX/GLB files.
+This repository contains a simple command line tool for copying FBX/GLB files
+and previewing them in a small 3D viewer. The viewer automatically rotates the
+model so you can quickly inspect an asset.
 
 ## Usage
 
 ```bash
+# copy the model to another path
 python src/main.py <input_file> <output_file>
+
+# preview a model
+python src/main.py <input_file> --preview
+
+# preview without copying by omitting the output file
+python src/main.py <input_file>
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-# Currently this project only relies on the Python standard library.
-# Add additional dependencies here when needed.
+open3d

--- a/src/main.py
+++ b/src/main.py
@@ -8,17 +8,51 @@ def copy_file(input_path: Path, output_path: Path) -> None:
     output_path.write_bytes(data)
 
 
+def preview_model(model_path: Path) -> None:
+    """Open a window displaying the model spinning slowly."""
+    import open3d as o3d
+
+    mesh = o3d.io.read_triangle_mesh(str(model_path))
+    if mesh.is_empty():
+        raise ValueError(f"Could not load 3D model from {model_path}")
+    mesh.compute_vertex_normals()
+
+    def rotate(vis: o3d.visualization.Visualizer) -> None:
+        ctr = vis.get_view_control()
+        ctr.rotate(2.0, 0.0)
+
+    o3d.visualization.draw_geometries_with_animation_callback([mesh], rotate)
+
+
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Simple 3D FBX/GLB file copier")
-    parser.add_argument("input", type=Path, help="Path to the input FBX/GLB file")
-    parser.add_argument("output", type=Path, help="Path where the output file will be written")
+    parser = argparse.ArgumentParser(
+        description="Simple 3D FBX/GLB file copier and previewer"
+    )
+    parser.add_argument(
+        "input", type=Path, help="Path to the input FBX/GLB file"
+    )
+    parser.add_argument(
+        "output",
+        type=Path,
+        nargs="?",
+        help="Optional path where the output file will be written",
+    )
+    parser.add_argument(
+        "--preview",
+        action="store_true",
+        help="Preview the model in a rotating window",
+    )
     return parser.parse_args()
 
 
 def main() -> None:
     args = parse_args()
-    copy_file(args.input, args.output)
-    print(f"Copied {args.input} to {args.output}")
+    if args.output is not None:
+        copy_file(args.input, args.output)
+        print(f"Copied {args.input} to {args.output}")
+
+    if args.preview or args.output is None:
+        preview_model(args.input)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- preview models in a rotating Open3D window
- allow optional copy step
- document usage for copying and previewing
- add Open3D requirement

## Testing
- `python -m py_compile src/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68599419c7cc83309a4b9548e8ac4db7